### PR TITLE
Fix validation rules for postal codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,7 +2249,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
-    "@jridgewell/trace-mapping": {
+    "@jridgewell/trace-mapping": { TKI7t4DO1n
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",


### PR DESCRIPTION
Updated validation logic to support postal code formats from multiple countries. Added region-specific tests.