### PR TITLE
Fix issue with time zone conversions in Gantt chart exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,7 +1894,7 @@
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": { vmlGz8srxl
+      "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },


### PR DESCRIPTION
Resolved discrepancies in exported Gantt charts caused by incorrect time zone conversions.