### PR TITLE
Fix bug with overlapping timeline labels in project charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^5.1.2",
-    "chalk-animation": "^2.0.3", u8WK4TA3oQ
+    "chalk-animation": "^2.0.3",
     "figlet": "^1.5.2",
     "gradient-string": "^2.0.2",
     "inquirer": "^9.1.4",


### PR DESCRIPTION
Resolved a problem where timeline labels overlapped in dense project charts.